### PR TITLE
0.9.0 Manual

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ocefpaf
+* @hobu @ocefpaf

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About rtree
 
 Home: http://toblerity.github.com/rtree/
 
-Package license: LGPL-2.1
+Package license: MIT
 
 Feedstock license: BSD 3-Clause
 
@@ -211,5 +211,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@hobu](https://github.com/hobu/)
 * [@ocefpaf](https://github.com/ocefpaf/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.8.3" %}
+{% set version = "0.9.0" %}
 
 package:
   name: rtree
@@ -6,13 +6,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/R/Rtree/Rtree-{{ version }}.tar.gz
-  sha256: 6cb9cf3000963ea6a3db777a597baee2bc55c4fc891e4f1967f262cc96148649
-  patches:
-    - find_libray.patch
-    - setup-win.patch  # [win]
+  sha256: 37ce6017359f106d6ce25864b42bff7a4ed5eb9dce8d2793d40b328cafc1b9c9
 
 build:
-  number: 1003
+  number: 0
   skip: True  # [win and vc<14]
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"  # [not win]
 
@@ -38,3 +35,4 @@ about:
 extra:
   recipe-maintainers:
     - ocefpaf
+    - hobu

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ test:
 
 about:
   home: http://toblerity.github.com/rtree/
-  license: LGPL-2.1
+  license: MIT
   license_file: LICENSE.txt
   summary: 'R-Tree spatial index for Python GIS'
 


### PR DESCRIPTION
* Add @hobu as a maintainer
* Rtree 0.9.0 is now MIT-licensed
* No more library path patching should be required
* Rerendered