### PR TITLE
Fix provider in conda-forge.yml

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,4 +1,2 @@
-provider:
-  win: azure
 conda_forge_output_validation: true
-provider: {linux_aarch64: default}
+provider: {linux_aarch64: default, win: azure}


### PR DESCRIPTION
The `provider` field in the the `conda-forge.yml` file is duplicated causing the arch migrator bot to fail:

```
Error: bot error (bot CI job): master: Traceback (most recent call last): File "/home/runner/work/autotick-bot/autotick-bot/cf-scripts/conda_forge_tick/auto_tick.py", line 1134, in main migrator_uid, pr_json = run( File "/home/runner/work/autotick-bot/autotick-bot/cf-scripts/conda_forge_tick/auto_tick.py", line 193, in run migrate_return = migrator.migrate(recipe_dir, feedstock_ctx.attrs, **kwargs) File "/home/runner/work/autotick-bot/autotick-bot/cf-scripts/conda_forge_tick/migrators/arch.py", line 117, in migrate y = safe_load(f) File "/usr/share/miniconda/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/main.py", line 1118, in safe_load return load(stream, SafeLoader, version) File "/usr/share/miniconda/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/main.py", line 1071, in load return loader._constructor.get_single_data() File "/usr/share/miniconda/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 122, in get_single_data return self.construct_document(node) File "/usr/share/miniconda/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 132, in construct_document for _dummy in generator: File "/usr/share/miniconda/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 722, in construct_yaml_map value = self.construct_mapping(node) File "/usr/share/miniconda/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 446, in construct_mapping return BaseConstructor.construct_mapping(self, node, deep=deep) File "/usr/share/miniconda/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 264, in construct_mapping if self.check_mapping_key(node, key_node, mapping, key, value): File "/usr/share/miniconda/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 295, in check_mapping_key raise DuplicateKeyError(*args) ruamel.yaml.constructor.DuplicateKeyError: while constructing a mapping in "conda-forge.yml", line 1, column 1 found duplicate key "provider" with value "{}" (original value: "{}") in "conda-forge.yml", line 4, column 1 To suppress this check see: http://yaml.readthedocs.io/en/latest/api.html#duplicate-keys Duplicate keys will become an error in future releases, and are errors by default when using the new API. 
 ```


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
